### PR TITLE
Fixes event check and adds more tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ gem 'faraday'
 gem 'oj'
 
 group :test do
-  gem 'simplecov-console'
   gem 'factory_bot'
   gem 'faker'
   gem 'rspec'
+  gem 'simplecov-console'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'faraday'
 gem 'oj'
 
 group :test do
+  gem 'simplecov-console'
   gem 'factory_bot'
   gem 'faker'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ansi (1.5.0)
     ast (2.4.0)
     awesome_print (1.8.0)
     coderay (1.1.2)
@@ -78,7 +79,13 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-console (0.6.0)
+      ansi
+      simplecov
+      terminal-table
     simplecov-html (0.10.2)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
@@ -107,6 +114,7 @@ DEPENDENCIES
   rubocop (>= 0.74.0)
   rubocop-performance (>= 1.4.1)
   simplecov (>= 0.17.0)
+  simplecov-console
   site_mercado!
   vcr (>= 5.0.0)
   webmock (>= 3.7.6)

--- a/lib/site_mercado.rb
+++ b/lib/site_mercado.rb
@@ -15,6 +15,7 @@ require 'site_mercado/entities/customer'
 require 'site_mercado/entities/order'
 require 'site_mercado/entities/payment'
 require 'site_mercado/entities/item'
+require 'site_mercado/entities/transaction'
 require 'site_mercado/entities/product'
 
 require 'site_mercado/resources/v1/event'

--- a/lib/site_mercado/entities/event.rb
+++ b/lib/site_mercado/entities/event.rb
@@ -36,8 +36,20 @@ module SiteMercado
         state == 'SEP'
       end
 
-      def separeted?
+      def awaiting_delivery?
+        state == 'ENT'
+      end
+
+      def awaiting_withdrawal?
         state == 'RET'
+      end
+
+      def awaiting_export?
+        state == 'PE0'
+      end
+
+      def exported?
+        state == 'PE1'
       end
 
       def canceled?

--- a/lib/site_mercado/entities/payment.rb
+++ b/lib/site_mercado/entities/payment.rb
@@ -26,7 +26,7 @@ module SiteMercado
         super(params, ATTRS, DICTIONARY)
 
         @transactions = @transactions.map do |transaction|
-          SiteMercado::Transaction.new(transaction)
+          SiteMercado::Entities::Transaction.new(transaction)
         end
       end
 

--- a/lib/site_mercado/entities/transaction.rb
+++ b/lib/site_mercado/entities/transaction.rb
@@ -1,29 +1,33 @@
+# frozen_literal_string: true
+
 module SiteMercado
-  class Transaction
-    DICTIONARY = {
-      bandeira: :flag,
-      inicioCartao: :first_digits,
-      fimCartao: :last_digits,
-      adquirente: :owner,
-      transactionCode1: :code1,
-      transactionCode2: :code2,
-      valor: :value,
-      dataHora: :date_time
-    }.freeze
+  module Entities
+    class Transaction < Base
+      DICTIONARY = {
+        bandeira: :flag,
+        inicioCartao: :first_digits,
+        fimCartao: :last_digits,
+        adquirente: :owner,
+        transactionCode1: :code1,
+        transactionCode2: :code2,
+        valor: :value,
+        dataHora: :date_time
+      }.freeze
 
-    ATTR = %i[
-      flag
-      first_digits
-      last_digits
-      owner
-      code1
-      code2
-      value
-      date_time
-    ].freeze
+      ATTRS = %i[
+        flag
+        first_digits
+        last_digits
+        owner
+        code1
+        code2
+        value
+        date_time
+      ].freeze
 
-    def initialize(params)
-      super(params, ATTRS, DICTIONARY)
+      def initialize(params)
+        super(params, ATTRS, DICTIONARY)
+      end
     end
   end
 end

--- a/lib/site_mercado/errors/unknown_status_error.rb
+++ b/lib/site_mercado/errors/unknown_status_error.rb
@@ -5,7 +5,7 @@ require 'oj'
 module SiteMercado
   module Errors
     class UnknownStatusError < StandardError
-      attr_reader :status, :body, :code, :description, :error, :id
+      attr_reader :status, :body
 
       def self.build_message(body)
         prefix = '[ERROR] Precondition Failed!'

--- a/lib/site_mercado/resources/v1/event.rb
+++ b/lib/site_mercado/resources/v1/event.rb
@@ -24,7 +24,7 @@ module SiteMercado
                  [{}]
                end
 
-        Client.post('/pedido/eventos/verificado', body)
+        Client.post('/pedido/eventos/verificado', body: body)
       end
     end
   end

--- a/lib/site_mercado/resources/v1/event.rb
+++ b/lib/site_mercado/resources/v1/event.rb
@@ -15,7 +15,7 @@ module SiteMercado
         end
       end
 
-      def check_event(ids)
+      def check(ids)
         body = if ids.is_a?(Array)
                  ids.map { |id| { id: id } }
                elsif ids.is_a?(Integer) || ids.is_a?(String)

--- a/site_mercado.gemspec
+++ b/site_mercado.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '>= 0.74.0'
   spec.add_development_dependency 'rubocop-performance', '>= 1.4.1'
   spec.add_development_dependency 'simplecov', '>= 0.17.0'
+  spec.add_development_dependency 'simplecov-console', '>= 0.6.0'
   spec.add_development_dependency 'vcr', '>= 5.0.0'
   spec.add_development_dependency 'webmock', '>= 3.7.6'
 end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -3,14 +3,54 @@
 require 'spec_helper'
 
 FactoryBot.define do
-  factory :event, class: 'OpenStruct' do
-    trait :response do
-      id { Faker::Number.number(digits: 5) }
-      codigoPedido { Faker::Alphanumeric.alpha(number: 7) }
-      status { SiteMercado::Entities::Event::STATUS.sample }
-      idLoja { Faker::Number.number(digits: 5) }
+  factory :event, class: 'SiteMercado::Entities::Event' do
+    id { Faker::Number.number(digits: 5) }
+    codigoPedido { Faker::Alphanumeric.alpha(number: 7) }
+    status { SiteMercado::Entities::Event::STATUS.sample }
+    idLoja { Faker::Number.number(digits: 5) }
+
+    initialize_with do
+      new(
+        'id' => id,
+        'codigoPedido' => codigoPedido,
+        'status' => status,
+        'idLoja' => idLoja
+      )
     end
 
-    initialize_with { new(attributes) }
+    trait :invoiced do
+      status { 'EMI' }
+    end
+
+    trait :in_separation do
+      status { 'SEP' }
+    end
+
+    trait :awaiting_delivery do
+      status { 'ENT' }
+    end
+
+    trait :awaiting_withdrawal do
+      status { 'RET' }
+    end
+
+    trait :awaiting_export do
+      status { 'PE0' }
+    end
+
+    trait :exported do
+      status { 'PE1' }
+    end
+
+    trait :canceled do
+      status { 'CAN' }
+    end
+  end
+
+  factory :event_response, class: 'OpenStruct' do
+    id { Faker::Number.number(digits: 5) }
+    codigoPedido { Faker::Alphanumeric.alpha(number: 7) }
+    status { SiteMercado::Entities::Event::STATUS.sample }
+    idLoja { Faker::Number.number(digits: 5) }
   end
 end

--- a/spec/site_mercado/entities/customer_spec.rb
+++ b/spec/site_mercado/entities/customer_spec.rb
@@ -16,4 +16,28 @@ RSpec.describe SiteMercado::Entities::Customer do
     telefoneFixo
     enderecos
   ]
+
+  describe '.initialize' do
+    let(:params) do
+      {
+        'enderecos' => [
+          {
+            'id' => 43,
+            'logradouro' => 'itaim',
+            'numero' => 4134,
+            'complemento' => '*',
+            'uf' => 'SP',
+            'cidade' => 'Sao Paulo',
+            'estado' => 'Sao Paulo'
+          }
+        ]
+      }
+    end
+
+    subject { described_class.new(params).addresses }
+
+    it 'creates a address' do
+      expect(subject.first).to be_a(SiteMercado::Entities::Address)
+    end
+  end
 end

--- a/spec/site_mercado/entities/event_spec.rb
+++ b/spec/site_mercado/entities/event_spec.rb
@@ -7,4 +7,130 @@ RSpec.describe SiteMercado::Entities::Event do
     status
     idLoja
   ]
+
+  describe '.invoiced?' do
+    context 'when invoiced' do
+      let(:event) { build(:event, :invoiced) }
+
+      subject { event.invoiced? }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when not invoiced' do
+      let(:event) { build(:event, :in_separation) }
+
+      subject { event.invoiced? }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '.in_separation?' do
+    context 'when in_separation' do
+      let(:event) { build(:event, :in_separation) }
+
+      subject { event.in_separation? }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when not in_separation' do
+      let(:event) { build(:event, :awaiting_delivery) }
+
+      subject { event.in_separation? }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '.awaiting_delivery?' do
+    context 'when awaiting_delivery' do
+      let(:event) { build(:event, :awaiting_delivery) }
+
+      subject { event.awaiting_delivery? }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when not awaiting_delivery' do
+      let(:event) { build(:event, :awaiting_withdrawal) }
+
+      subject { event.awaiting_delivery? }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '.awaiting_withdrawal?' do
+    context 'when awaiting_withdrawal' do
+      let(:event) { build(:event, :awaiting_withdrawal) }
+
+      subject { event.awaiting_withdrawal? }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when not awaiting_withdrawal' do
+      let(:event) { build(:event, :awaiting_export) }
+
+      subject { event.awaiting_withdrawal? }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '.awaiting_export?' do
+    context 'when awaiting_export' do
+      let(:event) { build(:event, :awaiting_export) }
+
+      subject { event.awaiting_export? }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when not awaiting_export' do
+      let(:event) { build(:event, :exported) }
+
+      subject { event.awaiting_export? }
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe '.exported?' do
+    context 'when exported' do
+      let(:event) { build(:event, :exported) }
+
+      subject { event.exported? }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when not exported' do
+      let(:event) { build(:event, :canceled) }
+
+      subject { event.exported? }
+
+      it { is_expected.to eq false}
+    end
+  end
+
+  describe '.canceled?' do
+    context 'when canceled' do
+      let(:event) { build(:event, :canceled) }
+
+      subject { event.canceled? }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when not canceled' do
+      let(:event) { build(:event, :invoiced) }
+
+      subject { event.canceled? }
+
+      it { is_expected.to eq false }
+    end
+  end
 end

--- a/spec/site_mercado/entities/event_spec.rb
+++ b/spec/site_mercado/entities/event_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe SiteMercado::Entities::Event do
 
       subject { event.exported? }
 
-      it { is_expected.to eq false}
+      it { is_expected.to eq false }
     end
   end
 

--- a/spec/site_mercado/entities/order_spec.rb
+++ b/spec/site_mercado/entities/order_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe SiteMercado::Entities::Order do
     items
   ]
 
+  describe '.encoded_id' do
+    let(:order) { build(:order) }
+
+    subject { order.encoded_id }
+
+    after { subject }
+
+    it 'calls order parser helper' do
+      expect(SiteMercado::Helpers::OrderParser).to receive(:encode_id).with(order.id)
+    end
+  end
+
   describe '.total_payments' do
     let(:order) { build(:order) }
     let(:payments) { build_list(:payment, 5, valor: 10.0) }

--- a/spec/site_mercado/entities/payment_spec.rb
+++ b/spec/site_mercado/entities/payment_spec.rb
@@ -1,6 +1,36 @@
 require 'spec_helper'
 
-RSpec.describe SiteMercado::Entities::Order do
+RSpec.describe SiteMercado::Entities::Payment do
+  it_behaves_like 'entity_attributes', %i[
+    id
+    nome
+    valor
+    tipo
+    transacoes
+  ]
+
+  describe '.initialize' do
+    context 'creates transactions' do
+      let(:params) do
+        {
+          'transacoes' => [
+            {
+              'bandeira' => 'Mastercard',
+              'valor' => 32.50
+            }
+          ]
+        }
+      end
+      let(:payment) { described_class.new(params) }
+
+      subject { payment.transactions }
+
+      it 'expects to have transactions' do
+        expect(subject.first).to be_a(SiteMercado::Entities::Transaction)
+      end
+    end
+  end
+
   describe '.offline?' do
     subject { payment.offline? }
 

--- a/spec/site_mercado/errors/unknown_status_errors_spec.rb
+++ b/spec/site_mercado/errors/unknown_status_errors_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'oj'
+
+RSpec.describe SiteMercado::Errors::UnknownStatusError do
+  describe '#build_message' do
+    let(:body) do
+      {
+        'message' => 'error message',
+        'data1' => '5324',
+        'data2' => '1234'
+      }
+    end
+    let(:metadata) do
+      {
+        'data1' => '5324',
+        'data2' => '1234'
+      }
+    end
+
+    let(:message) do
+      "[ERROR] Precondition Failed! API Message: 'error message' metadata: #{metadata}"
+    end
+
+    subject { described_class.build_message(body) }
+
+    it 'returs a formatted message' do
+      is_expected.to eq(message)
+    end
+  end
+
+  describe '.initialize' do
+    subject { described_class.new(response) }
+
+    context 'when response is given' do
+      let(:body) { { foo: 'bar' }.to_json }
+      let(:response) { double(status: 422, body: body) }
+
+      it 'exception has body attributes' do
+        expect(subject.body).to eq(Oj.load(body))
+      end
+
+      it 'exception has status attributes' do
+        expect(subject.status).to eq(422)
+      end
+    end
+
+    context 'when response is nil' do
+      let(:response) { nil }
+    end
+  end
+end

--- a/spec/site_mercado/resources/v1/event_spec.rb
+++ b/spec/site_mercado/resources/v1/event_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe SiteMercado::Event do
   describe '#all' do
-    let(:response) { build_list(:event, 5, :response).map(&:marshal_dump) }
+    let(:response) { build_list(:event_response, 5).map(&:marshal_dump) }
     let(:events) { response.map { |event| SiteMercado::Entities::Event.new(event) } }
 
     before { allow(SiteMercado::Client).to receive(:get).and_return(response) }
@@ -35,7 +35,7 @@ RSpec.describe SiteMercado::Event do
 
   describe '#find_by_shop_id' do
     let(:shop_id) { Faker::Number.number }
-    let(:response) { build_list(:event, 5, :response).map(&:marshal_dump) }
+    let(:response) { build_list(:event_response, 5).map(&:marshal_dump) }
     let(:events) { response.map { |event| SiteMercado::Entities::Event.new(event) } }
 
     before { allow(SiteMercado::Client).to receive(:get).and_return(response) }
@@ -68,7 +68,7 @@ RSpec.describe SiteMercado::Event do
   end
 
   describe '#check_event' do
-    let(:events) { build_list(:event, 5, :response) }
+    let(:events) { build_list(:event_response, 5) }
     before { allow(SiteMercado::Client).to receive(:post) }
 
     subject { described_class.check_event(ids) }
@@ -81,7 +81,7 @@ RSpec.describe SiteMercado::Event do
         expect(SiteMercado::Client).to(
           receive(:post)
           .once
-          .with('/pedido/eventos/verificado', body)
+          .with('/pedido/eventos/verificado', body: body)
         )
         subject
       end
@@ -95,7 +95,7 @@ RSpec.describe SiteMercado::Event do
         expect(SiteMercado::Client).to(
           receive(:post)
           .once
-          .with('/pedido/eventos/verificado', body)
+          .with('/pedido/eventos/verificado', body: body)
         )
         subject
       end
@@ -109,7 +109,7 @@ RSpec.describe SiteMercado::Event do
         expect(SiteMercado::Client).to(
           receive(:post)
           .once
-          .with('/pedido/eventos/verificado', body)
+          .with('/pedido/eventos/verificado', body: body)
         )
         subject
       end
@@ -123,7 +123,7 @@ RSpec.describe SiteMercado::Event do
         expect(SiteMercado::Client).to(
           receive(:post)
           .once
-          .with('/pedido/eventos/verificado', body)
+          .with('/pedido/eventos/verificado', body: body)
         )
         subject
       end

--- a/spec/site_mercado/resources/v1/event_spec.rb
+++ b/spec/site_mercado/resources/v1/event_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe SiteMercado::Event do
     end
   end
 
-  describe '#check_event' do
+  describe '#check' do
     let(:events) { build_list(:event_response, 5) }
     before { allow(SiteMercado::Client).to receive(:post) }
 
-    subject { described_class.check_event(ids) }
+    subject { described_class.check(ids) }
 
     context 'when array of ids' do
       let(:ids) { events.map(&:id) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'simplecov'
+require 'simplecov-console'
 require 'support/configs/simple_cov_config'
 SimpleCovConfig.configure
 

--- a/spec/support/configs/simple_cov_config.rb
+++ b/spec/support/configs/simple_cov_config.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 
 module SimpleCovConfig
   def self.configure
+    SimpleCov.formatter = SimpleCov::Formatter::Console
     SimpleCov.minimum_coverage 60
     SimpleCov.start do
       add_filter { |source_file| cover?(source_file.lines) }


### PR DESCRIPTION
[Monday](https://petlove-team.monday.com/boards/435101756/pulses/445055887)
* Fixes usage of `Client.post` in `check_event` resource
* Adds `simplecov-console`
* Adds more test for missing files coverage
* Adds more status according to https://sitemercado.octadesk.com/kb/article/extranet-siglas-de-status-relatorio-de-vendas-simplificado doc